### PR TITLE
[김봉철] 제품 상세페이지 

### DIFF
--- a/products/urls.py
+++ b/products/urls.py
@@ -1,7 +1,8 @@
 from django.urls    import path
-from products.views import ProductListView 
+from products.views import ProductListView, DetailView
 
 app_name = 'products'
 urlpatterns = [
     path('', ProductListView.as_view()),
+    path('/details/<int:details_id>', DetailView.as_view()),
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -2,7 +2,7 @@ from django.views       import View
 from django.http        import JsonResponse
 from django.db.models   import Sum
 
-from products.models    import MainCategory, SubCategory, Product
+from products.models    import MainCategory, SubCategory, Product, ProductOption
 
 class CategoryListView(View):
     def get(self, request):
@@ -45,3 +45,30 @@ class ProductListView(View):
         } for product in Product.objects.filter(**filter_set).order_by(ordering)]
 
         return JsonResponse({'results' : results}, status = 200)
+
+class DetailView(View):
+    def get(self, request, details_id):
+        try:
+            product   = Product.objects.get(id=details_id)
+            images    = [i['url'] for i in product.productimage_set.filter(product_id=product.id).values('url')]
+            po_sort   = ProductOption.objects.all().order_by('size_id')
+            size_quan = [{"sizeName" : po.size.type, "quantity" : po.quantity} for po in po_sort.filter(product_id=product.id)]
+            results   = {
+                "product_id"        : product.id,
+                "price"             : product.price,
+                "product_images"    : images,
+                "sub_title"         : product.sub_title,
+                "title"             : product.title,
+                "price"             : int(product.price),
+                "eco_friendly"      : product.eco_friendly,
+                "size_quan"         : size_quan,
+                "description_title" : product.description_title,
+                "description"       : product.description,
+                "current_color"     : product.current_color,
+                "serial"            : product.serial
+            }
+
+            return JsonResponse({'results' : results}, status = 200)
+
+        except KeyError:
+            return JsonResponse({"message" : "KEY_ERROR"}, status=401)        


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 제품 상세페이지에 필요한 정보들을 db에서 꺼내어 프론트엔드에 전달한다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. products 테이블에서 제품에 대한 대부분의 값을 가져옵니다.
2. product_options 테이블에서 사이즈와 수량, 컬러 값을 가져옵니다.
이 과정에서 역참조가 필요했습니다.
3. 프론트엔드에서 사이즈와 수량 값 전달 시 sizeName / quantity 형식으로 보내달라고 요청하여 
알맞게 수정했습니다.
4. 프론트엔드에서 사이즈와 수량 값 전달 시 오름차순으로 값 전달을 요청하여 order_by를 활용해 구현해 봤습니다.
5. 프론트엔드에서 price 부분 소수점을 빼달라고 요청하여 (멘토님 리뷰) int로 해당 값을 감싸는 형태로 처리했습니다.
6. 프론트엔드에 정상적으로 값이 전달되는 부분까지 확인했습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 백엔드에서 프론트엔드로 값을 어떻게 전달하고 그 값들이 어떻게 표현되는지 볼 수 있는 기회였습니다.
- 참조를 위한 테이블 접근에 대한 공부를 할 수 있는 계기였습니다.

<br />

## :: 기타 질문 및 특이 사항

![Screen Shot 2021-11-08 at 6 29 32 PM](https://user-images.githubusercontent.com/81699882/140717318-6f562f66-e977-4f74-8b7c-04c37ca7bad3.png)

