### PR TITLE
[김봉철]modify: 회원가입 전화번호 하이픈 없이 숫자만 받기, 이메일과 비밀번호 에러 메시지 특정 못 하게 반환

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -21,6 +21,9 @@ class SignupView(View):
             if not re.match('^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[~₩!@#$%^&*()\-_=+])[a-zA-Z0-9~!@#$%^&*()_\-+=]{8,}$', password):
                 return JsonResponse({"message" : "PASSWORD_VALIDATION_ERROR"}, status=400)
             
+            if not re.match('^(?=.*[0-9]{10,11}$', phone_number):
+                return JsonResponse({"message" : "PHONE_NUMBER_VALIDATION_ERROR"}, status=400)
+            
             if User.objects.filter(email=email).exists():
                 return JsonResponse({"message" : "DUPLICATION_ERROR"}, status=400)
 

--- a/users/views.py
+++ b/users/views.py
@@ -16,10 +16,10 @@ class SignupView(View):
             phone_number = data["phone_number"]
             
             if not re.match('^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-_]+$', email):
-                return JsonResponse({"message" : "EMAIL_VALIDATION_ERROR"}, status=400)
+                return JsonResponse({"message" : "EMAIL OR PASSWORD VALIDATION_ERROR"}, status=400)
 
             if not re.match('^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[~₩!@#$%^&*()\-_=+])[a-zA-Z0-9~!@#$%^&*()_\-+=]{8,}$', password):
-                return JsonResponse({"message" : "PASSWORD_VALIDATION_ERROR"}, status=400)
+                return JsonResponse({"message" : "EMAIL OR PASSWORD VALIDATION_ERROR"}, status=400)
             
             if not re.match('^(?=.*[0-9]{10,11}$', phone_number):
                 return JsonResponse({"message" : "PHONE_NUMBER_VALIDATION_ERROR"}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 해커가 이메일과 비밀번호 중 어떤 값이 틀렸는지 특정 못하도록 메시지 동일하게 반환합니다.
- 전화번호 검색 조건 추가(하이픈 없이 숫자만 10~11자만 가능하도록 합니다.)


